### PR TITLE
Add comprehensive test suites for handlers and store

### DIFF
--- a/app/handlers/lilurl/lilurl_test.go
+++ b/app/handlers/lilurl/lilurl_test.go
@@ -1,0 +1,280 @@
+package lilurl_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/jmoiron/sqlx"
+	_ "github.com/mattn/go-sqlite3"
+	handler "github.com/pansachin/lilurl/app/handlers/lilurl"
+)
+
+const testSchema = `CREATE TABLE urls (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	long_url VARCHAR(255) NOT NULL,
+	short VARCHAR(7) NOT NULL,
+	created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	deleted_at DATETIME DEFAULT NULL
+)`
+
+func newTestDB(t *testing.T) *sqlx.DB {
+	t.Helper()
+	db, err := sqlx.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	if _, err := db.Exec(testSchema); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func newTestApp(t *testing.T) *fiber.App {
+	t.Helper()
+	db := newTestDB(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	h := handler.NewHandler(db, logger)
+
+	app := fiber.New()
+	app.Get("/health", func(c fiber.Ctx) error {
+		return c.Status(fiber.StatusOK).JSON(fiber.Map{"status": "ok"})
+	})
+	app.Post("/api/v1/lilurl", h.Create)
+	app.Get("/api/v1/short/:lilurl", h.GetByShortURL)
+	app.Get("/api/v1/id/:id", h.GetByID)
+	app.Delete("/api/v1/:id", h.Delete)
+	app.Get("/:lilurl", h.Get)
+	return app
+}
+
+// createShortURL is a helper that POSTs a URL and returns the result map.
+func createShortURL(t *testing.T, app *fiber.App, longURL string) map[string]interface{} {
+	t.Helper()
+	body, _ := json.Marshal(map[string]string{"long_url": longURL})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/lilurl", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("createShortURL() status = %d, want 201, body = %s", resp.StatusCode, b)
+	}
+	var envelope struct {
+		Result map[string]interface{} `json:"result"`
+	}
+	json.NewDecoder(resp.Body).Decode(&envelope)
+	return envelope.Result
+}
+
+func TestHealth(t *testing.T) {
+	app := newTestApp(t)
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("GET /health status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestCreate_ValidInput(t *testing.T) {
+	app := newTestApp(t)
+	body := bytes.NewBufferString(`{"long_url":"https://example.com"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/lilurl", body)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		t.Errorf("Create() status = %d, want 201", resp.StatusCode)
+	}
+
+	var envelope struct {
+		Result map[string]interface{} `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if envelope.Result["short"] == "" {
+		t.Error("Create() short is empty in response")
+	}
+}
+
+func TestCreate_MalformedJSON(t *testing.T) {
+	app := newTestApp(t)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/lilurl", bytes.NewBufferString(`{invalid`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("Create() malformed JSON status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestCreate_InvalidURL(t *testing.T) {
+	app := newTestApp(t)
+	body := bytes.NewBufferString(`{"long_url":"not-a-valid-url"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/lilurl", body)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("Create() invalid URL status = %d, want 500", resp.StatusCode)
+	}
+}
+
+func TestGetByShortURL_Found(t *testing.T) {
+	app := newTestApp(t)
+	created := createShortURL(t, app, "https://example.com")
+	short := created["short"].(string)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/short/"+short, nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("GetByShortURL() status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestGetByShortURL_NotFound(t *testing.T) {
+	app := newTestApp(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/short/doesntexist", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("GetByShortURL() not-found status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestGetByID_Found(t *testing.T) {
+	app := newTestApp(t)
+	created := createShortURL(t, app, "https://example.com")
+	id := strconv.Itoa(int(created["id"].(float64)))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/id/"+id, nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("GetByID() status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestGetByID_NotFound(t *testing.T) {
+	app := newTestApp(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/id/99999", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("GetByID() not-found status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestGetByID_InvalidID(t *testing.T) {
+	app := newTestApp(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/id/notanumber", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("GetByID() invalid ID status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestGet_Redirect(t *testing.T) {
+	app := newTestApp(t)
+	created := createShortURL(t, app, "https://example.com")
+	short := created["short"].(string)
+
+	req := httptest.NewRequest(http.MethodGet, "/"+short, nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	if resp.StatusCode != http.StatusTemporaryRedirect {
+		t.Errorf("Get() status = %d, want 307", resp.StatusCode)
+	}
+	if loc := resp.Header.Get("Location"); loc != "https://example.com" {
+		t.Errorf("Get() Location = %q, want %q", loc, "https://example.com")
+	}
+}
+
+func TestGet_NotFound(t *testing.T) {
+	app := newTestApp(t)
+	req := httptest.NewRequest(http.MethodGet, "/doesnotexist", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("Get() not-found status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestDelete_Success(t *testing.T) {
+	app := newTestApp(t)
+	created := createShortURL(t, app, "https://example.com")
+	id := strconv.Itoa(int(created["id"].(float64)))
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/"+id, nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("Delete() status = %d, want 204", resp.StatusCode)
+	}
+}
+
+func TestDelete_NotFound(t *testing.T) {
+	app := newTestApp(t)
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/99999", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("Delete() not-found status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestDelete_InvalidID(t *testing.T) {
+	app := newTestApp(t)
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/notanumber", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("Delete() invalid ID status = %d, want 400", resp.StatusCode)
+	}
+}

--- a/app/models/lilurl/db/store_test.go
+++ b/app/models/lilurl/db/store_test.go
@@ -1,0 +1,215 @@
+package store_test
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	_ "github.com/mattn/go-sqlite3"
+	store "github.com/pansachin/lilurl/app/models/lilurl/db"
+)
+
+const testSchema = `CREATE TABLE urls (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	long_url VARCHAR(255) NOT NULL,
+	short VARCHAR(7) NOT NULL,
+	created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	deleted_at DATETIME DEFAULT NULL
+)`
+
+func newTestDB(t *testing.T) *sqlx.DB {
+	t.Helper()
+	db, err := sqlx.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	if _, err := db.Exec(testSchema); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func newTestStore(t *testing.T) *store.Store {
+	t.Helper()
+	return store.New(newTestDB(t), slog.New(slog.NewTextHandler(io.Discard, nil)))
+}
+
+func newEntry() store.LilURL {
+	now := time.Now().Truncate(time.Second)
+	return store.LilURL{
+		Long:      "https://example.com",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+}
+
+func TestStore_Create(t *testing.T) {
+	s := newTestStore(t)
+	result, err := s.Create(newEntry())
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if result.ID == 0 {
+		t.Error("Create() ID = 0, want non-zero")
+	}
+	if result.Long != "https://example.com" {
+		t.Errorf("Create() Long = %q, want %q", result.Long, "https://example.com")
+	}
+	if result.Short == "" {
+		t.Error("Create() Short is empty")
+	}
+}
+
+func TestStore_GetByID(t *testing.T) {
+	s := newTestStore(t)
+	created, err := s.Create(newEntry())
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	got, err := s.GetByID(int64(created.ID))
+	if err != nil {
+		t.Fatalf("GetByID() error = %v", err)
+	}
+	if got.ID != created.ID {
+		t.Errorf("GetByID() ID = %d, want %d", got.ID, created.ID)
+	}
+	if got.Short != created.Short {
+		t.Errorf("GetByID() Short = %q, want %q", got.Short, created.Short)
+	}
+	if got.Long != created.Long {
+		t.Errorf("GetByID() Long = %q, want %q", got.Long, created.Long)
+	}
+}
+
+func TestStore_GetByID_NotFound(t *testing.T) {
+	s := newTestStore(t)
+	got, err := s.GetByID(99999)
+	if err != nil {
+		t.Fatalf("GetByID() error = %v", err)
+	}
+	if got.ID != 0 {
+		t.Errorf("GetByID() not-found should return zero ID, got %d", got.ID)
+	}
+}
+
+func TestStore_GetByShortURL(t *testing.T) {
+	s := newTestStore(t)
+	created, err := s.Create(newEntry())
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	got, err := s.GetByShortURL(created.Short)
+	if err != nil {
+		t.Fatalf("GetByShortURL() error = %v", err)
+	}
+	if got.ID != created.ID {
+		t.Errorf("GetByShortURL() ID = %d, want %d", got.ID, created.ID)
+	}
+	if got.Long != created.Long {
+		t.Errorf("GetByShortURL() Long = %q, want %q", got.Long, created.Long)
+	}
+}
+
+func TestStore_GetByShortURL_NotFound(t *testing.T) {
+	s := newTestStore(t)
+	got, err := s.GetByShortURL("notexist")
+	if err != nil {
+		t.Fatalf("GetByShortURL() error = %v", err)
+	}
+	if got.ID != 0 {
+		t.Errorf("GetByShortURL() not-found should return zero ID, got %d", got.ID)
+	}
+}
+
+func TestStore_Delete(t *testing.T) {
+	s := newTestStore(t)
+	created, err := s.Create(newEntry())
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	if err := s.Delete(int64(created.ID)); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+
+	got, err := s.GetByID(int64(created.ID))
+	if err != nil {
+		t.Fatalf("GetByID() after Delete() error = %v", err)
+	}
+	if got.ID != 0 {
+		t.Error("GetByID() returned deleted record")
+	}
+}
+
+func TestStore_Delete_NotFound(t *testing.T) {
+	s := newTestStore(t)
+	err := s.Delete(99999)
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("Delete() error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestStore_Delete_AlreadyDeleted(t *testing.T) {
+	s := newTestStore(t)
+	created, err := s.Create(newEntry())
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	if err := s.Delete(int64(created.ID)); err != nil {
+		t.Fatalf("first Delete() error = %v", err)
+	}
+
+	err = s.Delete(int64(created.ID))
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("second Delete() error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestStore_GetByID_ExcludesDeleted(t *testing.T) {
+	s := newTestStore(t)
+	created, err := s.Create(newEntry())
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	if err := s.Delete(int64(created.ID)); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+
+	got, err := s.GetByID(int64(created.ID))
+	if err != nil {
+		t.Fatalf("GetByID() error = %v", err)
+	}
+	if got.ID != 0 {
+		t.Error("GetByID() returned deleted record")
+	}
+}
+
+func TestStore_GetByShortURL_ExcludesDeleted(t *testing.T) {
+	s := newTestStore(t)
+	created, err := s.Create(newEntry())
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	if err := s.Delete(int64(created.ID)); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+
+	got, err := s.GetByShortURL(created.Short)
+	if err != nil {
+		t.Fatalf("GetByShortURL() error = %v", err)
+	}
+	if got.ID != 0 {
+		t.Error("GetByShortURL() returned deleted record")
+	}
+}


### PR DESCRIPTION
## Summary
This PR adds comprehensive test coverage for the lilurl application, including integration tests for HTTP handlers and unit tests for the data store layer.

## Key Changes
- **Handler Tests** (`app/handlers/lilurl/lilurl_test.go`): Added 280 lines of integration tests covering:
  - Health check endpoint
  - URL creation with valid/invalid/malformed inputs
  - Retrieval by short URL and ID with found/not-found scenarios
  - Redirect functionality for short URLs
  - Deletion with success/not-found/invalid ID cases
  - Proper HTTP status codes and response validation

- **Store Tests** (`app/models/lilurl/db/store_test.go`): Added 215 lines of unit tests covering:
  - CRUD operations (Create, Read, Delete)
  - Retrieval by ID and short URL with not-found handling
  - Soft delete functionality with proper exclusion of deleted records
  - Error handling for duplicate deletions
  - Test database setup with in-memory SQLite

## Notable Implementation Details
- Both test files use in-memory SQLite databases for fast, isolated test execution
- Tests include helper functions (`newTestDB`, `newTestApp`, `newTestStore`, `createShortURL`) to reduce duplication
- Handler tests use Fiber's test utilities with proper HTTP request/response validation
- Store tests verify that soft-deleted records are properly excluded from queries
- Comprehensive error case coverage including invalid IDs, malformed JSON, and not-found scenarios

https://claude.ai/code/session_01XUU1CS7LjRcSRFcECbcd2D